### PR TITLE
Implementing built in date formatting

### DIFF
--- a/internal/number_format/indexed.go
+++ b/internal/number_format/indexed.go
@@ -39,7 +39,7 @@ func init() {
 		0x0b: {ml.NumberFormat{ID: 0x0b, Code: `0.00E+00`}, Float},
 		0x0c: {ml.NumberFormat{ID: 0x0c, Code: `# ?/?`}, Float},
 		0x0d: {ml.NumberFormat{ID: 0x0d, Code: `# ??/??`}, Float},
-		0x0e: {ml.NumberFormat{ID: 0x0e, Code: `m-d-yy`}, Date},
+		0x0e: {ml.NumberFormat{ID: 0x0e, Code: `d/m/yyyy`}, Date},
 		0x0f: {ml.NumberFormat{ID: 0x0f, Code: `d-mmm-yy`}, Date},
 		0x10: {ml.NumberFormat{ID: 0x10, Code: `d-mmm`}, Date},
 		0x11: {ml.NumberFormat{ID: 0x11, Code: `mmm-yy`}, Date},
@@ -47,7 +47,7 @@ func init() {
 		0x13: {ml.NumberFormat{ID: 0x13, Code: `h:mm:ss AM/PM`}, Time},
 		0x14: {ml.NumberFormat{ID: 0x14, Code: `h:mm`}, Time},
 		0x15: {ml.NumberFormat{ID: 0x15, Code: `h:mm:ss`}, Time},
-		0x16: {ml.NumberFormat{ID: 0x16, Code: `m-d-yy h:mm`}, DateTime},
+		0x16: {ml.NumberFormat{ID: 0x16, Code: `m/d/yy H:mm`}, DateTime},
 		//...
 		0x25: {ml.NumberFormat{ID: 0x25, Code: `(#,##0_);(#,##0)`}, Integer},
 		0x26: {ml.NumberFormat{ID: 0x26, Code: `(#,##0_);[RED](#,##0)`}, Integer},

--- a/internal/number_format/types_test.go
+++ b/internal/number_format/types_test.go
@@ -6,6 +6,8 @@ package number
 
 import (
 	"github.com/plandem/xlsx/internal/ml"
+	"github.com/plandem/xlsx/internal/ml/primitives"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -43,4 +45,28 @@ func TestNumberFormat(t *testing.T) {
 
 	//custom ID was provided
 	require.Equal(t, ml.NumberFormat(ml.NumberFormat{ID: 1000, Code: ""}), New(1000, ""))
+}
+
+func TestDateFormat(t *testing.T) {
+	value := "36892.521"
+	var testCases = []struct {
+		code     string
+		expected string
+	}{
+		{"d/m/yyyy", "01/01/2001"},
+		{"d-mmm-yy", "01-Jan-01"},
+		{"d-mmm", "01-Jan"},
+		{"mmm-yy", "Jan-01"},
+		{"h:mm AM/PM", "12:30 PM"},
+		{"h:mm:ss AM/PM", "12:30:14 PM"},
+		{"h:mm", "12:30"},
+		{"h:mm:ss", "12:30:14"},
+		{"m/d/yy H:mm", "01/01/01 12:30"},
+	}
+	for _, test := range testCases {
+		t.Run(test.code, func(t *testing.T) {
+			result := Format(value, test.code, primitives.CellType(0))
+			assert.Equal(t, test.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
Currently, the number.Format method doesn't take into consideration the formatting code. This diff implements formatting for dates based on the code.
The implementation doesn't look at the cell data type because in cases of date it's not being populated by Excel, so it's always empty.